### PR TITLE
Use a more exhaustive glib2 search strategy on Linux

### DIFF
--- a/src/chafa/chafa.py
+++ b/src/chafa/chafa.py
@@ -37,6 +37,11 @@ if platform.system() == "Linux":
     _lib_glib = "libglib-2.0.so"
     _lib      = _root_dir / "libs" / "libchafa.so"
 
+    try:
+        ctypes.CDLL(_lib_glib)
+    except OSError:
+        _lib_glib = find_glib()
+
     if not _lib.exists():
         _lib = find_chafa()
 


### PR DESCRIPTION
After running in to an issue with software using `chafa.py` (https://github.com/joouha/euporie/issues/71), I found that `chafa.py`'s current hardcoded path for `glib` doesn't seem to work on Debian Bullseye. I added code to use `find_glib` on Linux as well if the hardcoded path doesn't work.