### PR TITLE
Fix canvas.draw_all_pixels argument order in PIL example

### DIFF
--- a/examples/example_PIL.py
+++ b/examples/example_PIL.py
@@ -25,8 +25,8 @@ canvas = Canvas(config)
 canvas.draw_all_pixels(
     PixelType.CHAFA_PIXEL_RGB8,
     pixels,
-    height,
     width,
+    height,
     width * bands
 )
 


### PR DESCRIPTION
This confused me so much when I was following the example because it looked like my image had been cut in half to show only the left half, and the bottom half of the image was completely messed up. 

`draw_all_pixels` has `width` before `height` in its arguments: https://github.com/GuardKenzie/chafa.py/blob/main/src/chafa/chafa.py#L2445-L2452