### PR TITLE
Fix: Release ImageMagick resources in `chafa.loader.Loader`

### DIFF
--- a/src/chafa/loader.py
+++ b/src/chafa/loader.py
@@ -110,6 +110,7 @@ class Loader:
         ]
 
         _MagickWand.DestroyPixelWand.argtypes = [ctypes.c_void_p]
+        _MagickWand.DestroyMagickWand.argtypes = [ctypes.c_void_p]
 
         _MagickWand.MagickGetImageWidth. argtypes = [ctypes.c_void_p]
         _MagickWand.MagickGetImageHeight.argtypes = [ctypes.c_void_p]
@@ -167,6 +168,9 @@ class Loader:
             CharPixel,
             pixels
         )
+
+        # Clean up wand to release resources
+        _MagickWand.DestroyMagickWand(magick_wand)
 
         self._height        = height
         self._width         = width

--- a/tests/7_load_many.py
+++ b/tests/7_load_many.py
@@ -1,0 +1,15 @@
+import chafa.loader
+
+# Uncomment to enable ImageMagick event logging:
+# import ctypes
+# chafa.loader._MagickWand.SetLogEventMask(ctypes.c_char_p(b'all\0'))
+
+# Load enough copies of 'snake.jpg' to reveal resource leaks.
+for i in range(1, 10_000+1):
+    img = chafa.loader.Loader('snake.jpg')
+    print(f'\x1b[G{i}', end='', flush=True)
+    if img.width == 0:
+        print(f'\x1b[GFailed after loading {i} copies of "snake.jpg"')
+        break
+else:
+    print('\nA-OK')


### PR DESCRIPTION
Recently I was experiencing problems loading many images with `chafa.py` so I went to investigate.  It turns out that `chafa.loader.Loader()` does not destroy the `MagicWand` object after exporting the image's pixels.

This PR is a minimal fix.  The loader should probably check for error conditions and raise an appropriate exception in that case.